### PR TITLE
docs(configuration): improve `yaml-files` code example

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -125,8 +125,9 @@ The default is:
 .. code-block:: yaml
 
  yaml-files:
- - '*.yaml'
- - '*.yml'
+   - '*.yaml'
+   - '*.yml'
+   - '.yamllint'
 
 The same rules as for ignoring paths applies
 (``.gitignore``-style path pattern,see below).


### PR DESCRIPTION
* A straight copy/paste of the existing example into the `.yamllint` file results in a `yamllint` error!
* Add `.yamllint` itself as a starting point for customisation.